### PR TITLE
Adding support to build docker image locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+!src
+!views
+!package.json
+!package-lock.json
+!tsconfig.json
+!gulpfile.js
+!scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-builder
 FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-runtime
 
+# Maintainer
+LABEL maintainer="Parental Advisory"
+
 RUN cp -r ./dist/views ./
 
-CMD ["./dist/app"]
 EXPOSE 3000
+CMD ["./dist/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-builder
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-runtime
+
+RUN cp -r ./dist/views ./
+
+CMD ["./dist/app"]
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ COOKIE_SECRET   |                       |
 
 ## Running in Docker locally
 
-This project uses the node-base-images(https://github.com/companieshouse/node-base-image) to build docker images. If running locally and connecting to services on host machine use `host.docker.internal` in place of localhost for environment variables.
+This project uses the node-base-image(https://github.com/companieshouse/node-base-image) to build docker images. If running locally and connecting to services on host machine use `host.docker.internal` in place of localhost for environment variables.
 
-1. Inside your `.chs_env` folder create a `restricted-word-web` folder and inside create a file named `env`. Place your environment variables here.
+1. Create the following folder structure `~/.chs_env/restricted-word-web`. Inside the `restricted-word-web` folder create a file named `env` and place your environment variables inside.
 2. Run `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="<YOUR_PRIVATE_KEY>" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t restricted-word-web .`
 3. Run `docker run --env-file ~/.chs_env/restricted-word-web/env -p 3000:3000 restricted-word-web`
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ The following is a list of mandatory environment variables for the service to ru
 
 Name                                        | Description                                                               | Example Value
 ------------------------------------------- | ------------------------------------------------------------------------- | ------------------------
-RESTRICTED_WORD_ADMIN_WEB_PORT              | Application Port                                                          | 8080
+RESTRICTED_WORD_ADMIN_WEB_PORT              | Application Port                                                          | 3000
 INTERNAL_API_URL                            | URL to Restricted Word Api                                                | http://internalapi.chs-dev.internal:4001
 CHS_INTERNAL_API_KEY                        | Internal API Key
+RESTRICTED_WORD_WEB_PORT                    | Application Port                                                           3000
+
+## Config variables
+
+Key             | Example Value         | Description
+----------------|-----------------------|------------------------------------
+CACHE_SERVER    | localhost:6379        | Required for storing values in memory(Redis)
+CDN_HOST        | http://cdn.chs.local  | Used when navigating to the webpage
+COOKIE_DOMAIN   | chs.local             |
+COOKIE_NAME     |__SID                  |
+COOKIE_SECRET   |                       |
 
 ## Installation
 
@@ -27,6 +38,15 @@ CHS_INTERNAL_API_KEY                        | Internal API Key
 3. npm install  (this installs the dependencies)
 4. make build
 
+## Running in Docker locally
+
+This project uses the node-base-images(https://github.com/companieshouse/node-base-image) to build docker images. If running locally and connecting to services on host machine use `host.docker.internal` in place of localhost for environment variables.
+
+1. Inside your `.chs_env` folder create a `restricted-word-web` folder and inside create a file named `env`. Place your environment variables here.
+2. Run `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="<YOUR_PRIVATE_KEY>" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t restricted-word-web .`
+3. Run `docker run --env-file ~/.chs_env/restricted-word-web/env -p 3000:3000 restricted-word-web`
+
+
 ## Testing  
 
 ### Local
@@ -34,6 +54,7 @@ CHS_INTERNAL_API_KEY                        | Internal API Key
 1. Have the restricted word api running on your same machine
 2. In project home directory `npm start`
 3. In browser go to <http://localhost:3001>
+
 
 ### Vagrant
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "## Description",
   "main": "app.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r views dist/ && gulp build",
     "build-scss": "gulp build",
     "build-js": "webpack --mode production",
-    "start": "node ./app/app",
+    "start": "node ./dist/app",
     "start:dev": "nodemon",
     "test": "mocha -r ts-node/register --recursive --reporter nyan test --extension ts",
     "test:watch": "mocha -r ts-node/register --recursive --reporter nyan test --extension ts --watch",
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/companieshouse/restricted-word-web#readme",
   "dependencies": {
-    "axios": "~0.21.1",
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#1.0.0",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a8112",
+    "axios": "~0.21.1",
     "chokidar": "^3.3.0",
     "cookie-parser": "~1.4.4",
     "express": "~4.17.1",

--- a/start.sh
+++ b/start.sh
@@ -29,4 +29,4 @@ else
 fi
 
 
-node app/app
+node dist/app

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
         "target": "es6",
         "module": "commonjs",
         "declaration": true,
-        "outDir": "./app",
+        "outDir": "./dist",
+        "baseUrl": "./src",
         "strict": true,
         "esModuleInterop": true,
         "pretty": true,
@@ -16,7 +17,7 @@
         ]
     },
     "include": [
-        "./src"
+        "./src/**/*"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
- Adding dockerfile that builds docker image using the node-base-image(https://github.com/companieshouse/node-base-image)
- Adding .dockerignore file
- Added gulp build to build script to solve issue where css files were not being built with app
- Updated readme