### PR TITLE
Remove reference to app directory which is causing pipeline failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ ifndef version
 endif
 	$(info Packaging version: $(version))
 	$(eval tmpdir := $(shell mktemp -d build-XXXXXXXXXX))
-	cp -r ./app $(tmpdir)
 	cp -r ./dist $(tmpdir)
 	cp -r ./views $(tmpdir)
 	cp -r ./package.json $(tmpdir)


### PR DESCRIPTION
Remove reference to "./app" from makefile (which is no longer used) as it caused concourse pipeline failure with error:

```
> tsc && cp -r views dist/ && gulp build

[10:44:28] Using gulpfile /tmp/build/404dfff8/source-code/gulpfile.js
[10:44:28] Starting 'build'...
[10:44:28] Starting 'sass'...
[10:44:28] Starting 'govuk-frontend-copy'...
[10:44:28] Finished 'govuk-frontend-copy' after 65 ms
[10:44:28] Finished 'sass' after 260 ms
[10:44:28] Finished 'build' after 262 ms
Packaging version: 0.1.44
cp -r ./app build-KMdX76jIya
cp: cannot stat './app': No such file or directory
```