### PR TITLE
Add missing test target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ build: clean init
 clean:
 	rm -rf dist/*
 
+.PHONY: test
+test:
+	npm run test:coverage
+
 .PHONY: test-unit
 test-unit:
 	npm run test


### PR DESCRIPTION
Makefile was missing a test target, this meant no test coverage report was output so sonar could not report the coverage on sonarqube.