### PR TITLE
Fix healthcheck endpoint to not require authentication

### DIFF
--- a/src/middleware/createAuthenticationMiddleware.ts
+++ b/src/middleware/createAuthenticationMiddleware.ts
@@ -12,7 +12,7 @@ const createAuthenticationMiddleware = function (): RequestHandler {
 
     return (request: Request, response: Response, next : NextFunction) => {
 
-        if (request.originalUrl === "/healthcheck") {
+        if (request.originalUrl === `/${config.urlPrefix}/healthcheck`) {
             logger.debug("/healthcheck endpoint called, skipping authentication.");
             return next();
         }

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -8,7 +8,7 @@ locals {
   lb_listener_rule_priority = 96
   lb_listener_paths         = ["/admin/restricted-word","/admin/restricted-word/*"]
   healthcheck_path          = "/admin/restricted-word/healthcheck" #healthcheck path for restricted word web
-  healthcheck_matcher       = "200-302"
+  healthcheck_matcher       = "200"
 
   kms_alias                 = "alias/${var.aws_profile}/environment-services-kms"
   service_secrets           = jsondecode(data.vault_generic_secret.service_secrets.data_json)

--- a/test/middleware/createAuthenticationMiddleware.test.ts
+++ b/test/middleware/createAuthenticationMiddleware.test.ts
@@ -183,7 +183,7 @@ describe("createAuthenticationMiddleware", function () {
     it("calls next and skips authentication if request is for the healthcheck url", function () {
 
         const mockRequest: any = {
-            originalUrl: "/healthcheck"
+            originalUrl: `/${mockConfig.urlPrefix}/healthcheck`
         };
 
         middleware(mockRequest, mockResponse, mockNext);


### PR DESCRIPTION
Healthcheck endpoint was requiring authentication as the url check in the middleware didn't match. This fixes it so that authentication is skipped for /admin/restricted-word/healthcheck calls