### PR TITLE
Resolve accessibility issues 

### DIFF
--- a/views/components/notification/template.njk
+++ b/views/components/notification/template.njk
@@ -2,7 +2,7 @@
   class="js-dismissible govuk-notification
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   aria-labelledby="notification-summary-title"
-  role="notification"
+  role="alert"
   tabindex="-1"
   {%- for attribute, value in params.attributes %}
     {{ attribute }}="{{ value }}"

--- a/views/includes/filters.html
+++ b/views/includes/filters.html
@@ -2,26 +2,30 @@
   <section class="filters" id="filters">
     <form action="/{{urlPrefix}}" method="GET" id="filter-form">
 
-      <div role="widget" class="filter open">
+      <div class="filter open">
         <div class="govuk-body filters-heading" role="button" aria-controls="filter-crn" aria-expanded="true" tabindex="0">
           <span id="filter-label-crn"></span>Search for word</span>
         <div class="toggle"></div>
       </div>
-      <div id="filter-crn" class="filters-wrapper" aria-hidden="true" aria-labelledby="filter-label-crn">
+      <div id="filter-crn" class="filters-wrapper" aria-labelledby="filter-label-crn" aria-controls="filter-crn">
         {{ govukInput({
             id: "filter-word",
             name: "filterWord",
-            value: filterParams.word
+            value: filterParams.word,
+            label: {
+              text: "Search for word",
+              classes: "govuk-visually-hidden"
+            }
           }) }}
       </div>
     </div>
 
 
-    <div role="widget" class="filter open">
+    <div class="filter open">
       <div class="govuk-body filters-heading" role="button" aria-controls="filter-crn" aria-expanded="true" tabindex="0">
         <span id="filter-label-status"><span class="govuk-visually-hidden">Filter by</span>Word type</span>
       </div>
-      <div id="filter-crn" class="filters-wrapper" aria-hidden="true" aria-labelledby="filter-label-crn">
+      <div id="filter-crn" class="filters-wrapper" aria-labelledby="filter-label-crn">
         {{ govukRadios({
           idPrefix: "filter-word-type",
           name: "filterSuperRestricted",
@@ -53,7 +57,7 @@
       </div>
     </div>
 
-    <div role="widget" class="filter open">
+    <div class="filter open">
       <div class="govuk-body filters-heading" role="button" aria-controls="filter-status" aria-expanded="true" tabindex="0">
         <span id="filter-label-status">
           <span class="govuk-visually-hidden">Filter by
@@ -90,8 +94,8 @@
           ]
         }) }}
     </div>
-    <div role="widget" class="filter open">
-      <div class="govuk-body filters-heading" role="button" aria-controls="filter-categories" aria-expanded="true" tabindex="0">
+    <div class="filter open">
+      <div class="govuk-body filters-heading" role="button" aria-controls="filter-label-cat" aria-expanded="true" tabindex="0">
         <span id="filter-label-cat">
           <span class="govuk-visually-hidden">Filter by
           </span>Categories</span>


### PR DESCRIPTION
Updated `filter.html` and word template to resolve accessibility issues found in Axe and Wave/Lighthouse scan. Including

1. adding id label to search box filter 
2. resolving issues aria tags on elements where invalid syntaxes were used in some places. 