### PR TITLE
Feature/pas 469 further accessibility issues

### DIFF
--- a/views/components/notification/template.njk
+++ b/views/components/notification/template.njk
@@ -1,7 +1,7 @@
 <div
   class="js-dismissible govuk-notification
   {%- if params.classes %} {{ params.classes }}{% endif %}"
-  aria-labelledby="notification-summary-title"
+  aria-labelledby="notification"
   role="alert"
   tabindex="-1"
   {%- for attribute, value in params.attributes %}

--- a/views/delete-word.html
+++ b/views/delete-word.html
@@ -25,7 +25,7 @@
       {% endif %}
 
       <h1 class="govuk-heading-xl">Delete word</h1>
-      <p class="govuk-body-l">You are about to delete <span>{{word}}</span></p>
+      <h2 class="govuk-body-l">You are about to delete <span>{{word}}</span></h2>
       <form method="POST" action="/{{urlPrefix}}/delete">
         <input type="hidden" name="id" value="{{ id }}" />
         <input type="hidden" name="word" value="{{ word }}" />

--- a/views/layout.html
+++ b/views/layout.html
@@ -94,7 +94,8 @@
       meta: {
         items: [
           {
-            text: "Companies House Internal Service"
+            text: "Companies House Internal Service",
+            href: "/" + urlPrefix
           }
         ]
       }


### PR DESCRIPTION
Resolves [PAS-469](https://companieshouse.atlassian.net/browse/PAS-469)

1. Fixes issue with aria label to match element id on notifications boxes  pop-ups 
2. change paragraph text to h2 header on delete, wave raised this as an alert
3. Add link onto Companies House Internal Service, it links back to the home page as -  according to design service,  footer macro requires a href and as Gareth pointed out its redundant at the moment 

[PAS-469]: https://companieshouse.atlassian.net/browse/PAS-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ